### PR TITLE
Add agent service, stress loader, and health-check scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,62 +1,156 @@
-# Cloud Vitals
+### ⚠️ **Under Active Development** ⚠️
 
-A custom remote-monitoring solution for Linux servers.
-It uses a Python agent on each VM and a central dashboard.
+This project is under active development and subject to change. APIs, configurations, and feature behavior may be updated or removed without notice.
+
+# About Cloud Vitals
+
+Cloud Vitals monitors Ubuntu servers with a lightweight Python agent and a central dashboard. The agent collects CPU, memory, disk, network, and swap metrics every second, writes JSON samples to a named pipe, and exposes REST endpoints to fetch data or trigger stress tests.
+
+You'll manage the agent with a `systemd` unit and a `cron`-based health check. The dashboard polls each agent, displays live and historical charts, and alerts you when metrics cross over your specified thresholds.
 
 ## Repository Layout
+
 ```
 ├── .gitignore
 ├── LICENSE
 ├── README.md
 ├── agent/
-│   ├── agent_venv/
-│   ├── agent.py
-│   ├── requirements.txt
-│   └── cloud-vitals-agent.service
-├── dashboard/
-│   ├── dash_venv/
-│   ├── dashboard.py
-│   └── requirements.txt
+│   ├── agent_venv/                    # Python virtual environment
+│   ├── agent.py                       # Main agent code
+│   ├── requirements.txt               # Flask, psutil, etc.
+│   ├── cloud_vitals_agent.service     # systemd unit file
+│   ├── cloud_vitals_stress.sh         # stress‑ng wrapper script
+│   └── cloud_vitals_agent_check.sh    # health‑check script
+└── dashboard/
+    ├── dash_venv/         # Python virtual environment
+    ├── dashboard.py       # GUI code
+    └── requirements.txt   # Dashboard dependencies
 ```
 
 ## Prerequisites
-- Ubuntu 24.04 LTS 
-- Python 3.12.3
-- A system user `useragent` on each VM
-- Port 5000 open between the dashboard and agents
+
+Before you begin, make sure you have the following:
+* **Ubuntu** 24.04 LTS
+* **Python** 3.12.3
+* A system user named `agentuser` on each VM
+* Port **5000** open so the dashboard can talk to the agents
+
+**Note:** These are the exact versions we used during development. Other Ubuntu LTS (or Debian‑based) releases and Python 3.12.x versions _might_ work but haven’t been verified.
 
 ## Firewall
-You need to forward port 5000 so your dashboard can pull data from the agent.
-On the VM, open port 5000/tcp:
+
+The dashboard and agent each communicate over TCP port 5000. You need to open this port on your VM's operating-system firewall **and** Google Cloud VPC firewall settings. With both OS-level and VPC firewall rules in place, your dashboard will be abvle to reach agent on port 5000.
+
+#### **1\. Operating-system firewall.**
+
 ```bash
-# If you use UFW:
+# If you are using UFW then enter this:
 sudo ufw allow 5000/tcp
 
-# If you use IPTables:
+# If you are using iptables then enter this:
 sudo iptables -A INPUT -p tcp --dport 5000 -j ACCEPT
 ```
+#### **2\. Google Cloud VPC Firewall** _(with GUI)_
+
+Make sure you have a rule (for example, `allow-agent-5000`) with these settings:
+* **Network**: `default`
+* **Direction**: `Ingress`
+* **Action**: `Allow`
+* **Targets**: instances tagged `cloud-vitals-agent`
+* **Source IPv4 ranges**: `0.0.0.0/0` _(or a narrower CIDR, if preferred)_
+* **Protocols and ports**: `tcp:5000`
+
+#### **3\. Google Cloud PVC Firewall** _(with CLI)_
+
+* Create/update the `allow-agent-5000` rule with the `gcloud` CLI using this command:
+   ```
+   gcloud compute firewall‐rules create allow-agent-5000 \
+      --network=default \
+      --direction=INGRESS \
+      --action=ALLOW \
+      --rules=tcp:5000 \
+      --source-ranges=0.0.0.0/0 \
+      --target-tags=cloud-vitals-agent \
+      --description="Allow the Cloud Vitals agent to share telemetry data."
+   ```
 
 ## Agent Install
-1. SSH into VM
-2. Install venv support: `sudo apt update && sudo apt install -y python3-venv`
-3. Copy your `agent/` folder to `/opt/cloudvitals/agent`
-4. Create the service user: `sudo useradd -r -s /usr/sbin/nologin agentuser`
-5. Switch to `agentuser` and set up the virtualenv:
+
+#### **1\. SSH into your VM.**
+
+#### **2\. Install Python virtual-env support and stress-ng.**
+
    ```bash
-   sudo -u agentuser bash
-   cd /opt/cloud-vitals/agent
-   python3 -m venv agent_venv
-   source agent_venv/bin/activate
-   pip install -r requirements.txt
-   exit
-   ```
-6. Deploy and start the service:
-   ```
-   sudo cp agent/cloud-vitals-agent.service /etc/systemd/system/
-   sudo systemctl daemon-reload
-   sudo systemctl enable cloud-vitals-agent
-   sudo systemctl start cloud-vitals-agent
+   sudo apt update
+   sudo apt install -y python3-venv stress-ng
    ```
 
-### Dashboard Install
-*(WIP)*
+#### **3\. Copy agent folder.**
+
+   ```bash
+   sudo mkdir -p /opt/cloud-vitals/agent
+   sudo cp -r ~/cloud-vitals/agent/* /opt/cloud-vitals/agent/
+   ```
+
+#### **4\. Create the service user and set permissions.**
+
+   ```bash
+   sudo useradd -r -s /usr/sbin/nologin agentuser
+   sudo chown -R agentuser:agentuser /opt/cloud-vitals/agent
+   ```
+
+#### **5\. Set up the Python environment and install dependencies.**
+
+   ```bash
+   sudo -u agentuser python3 -m venv /opt/cloud-vitals/agent/agent_venv
+   sudo -u agentuser /opt/cloud-vitals/agent/agent_venv/bin/pip install -r /opt/cloud-vitals/agent/requirements.txt
+   ```
+
+#### **6\. Make the helper scripts executable.**
+
+   ```bash
+   sudo chmod +x /opt/cloud-vitals/agent/cloud_vitals_stress.sh /opt/cloud-vitals/agent/cloud_vitals_agent_check.sh
+   ```
+
+#### **7\. Install and start the systemd service.**
+
+   ```bash
+   sudo cp /opt/cloud-vitals/agent/cloud_vitals_agent.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable cloud_vitals_agent
+   sudo systemctl start cloud_vitals_agent
+   ```
+
+#### **8\. Verify the agent**
+
+   ```bash
+   systemctl status cloud_vitals_agent
+   journalctl -u cloud_vitals_agent -f
+   ls -l /tmp/metrics_fifo             # Check the named pipe
+   curl http://localhost:5000/metrics  # Should return JSON
+   ```
+   
+#### **9\. Set up health‑check cron job**
+
+   * **Make sure the log file exists**:
+     ```bash
+     sudo touch /var/log/cloud-vitals-agent-check.log
+     sudo chmod 644 /var/log/cloud-vitals-agent-check.log
+     ```
+   * **Edit root's crontab**:
+     ```bash
+     sudo crontab -e
+     ```
+   * **Add the lin**:
+     ```cron
+     */5 * * * * /opt/cloud-vitals/agent/cloud_vitals_agent_check.sh >> /var/log/cloud-vitals-agent-check.log 2>&1
+     ```
+   * **Verify**:
+     ```bash
+     sudo crontab -l
+     tail -f /var/log/cloud-vitals-agent-check.log
+     ```
+
+## Dashboard Install (WIP)
+
+* To be completed once agent is verified.

--- a/agent/cloud_vitals_agent.service
+++ b/agent/cloud_vitals_agent.service
@@ -3,11 +3,14 @@ Description=Cloud Vitals Agent
 After=network.target
 
 [Service]
+Type=simple
 User=agentuser
+Group=agentuser
 WorkingDirectory=/opt/cloud-vitals/agent
-ExecStart=/opt/cloud-vitals/agent/venv/bin/python agent.py
+ExecStart=/opt/cloud-vitals/agent/agent_venv/bin/python3 /opt/cloud-vitals/agent/agent.py
 Restart=on-failure
 RestartSec=5
+Environment=PYTHONUNBUFFERED=1
 
 [Install]
 WantedBy=multi-user.target

--- a/agent/cloud_vitals_agent_check.sh
+++ b/agent/cloud_vitals_agent_check.sh
@@ -5,7 +5,6 @@
 SERVICE=cloud_vitals_agent
 
 if ! systemctl is-active --quiet "$SERVICE"; then
-  echo "$(date '+%Y-%m-%d %H:%M:%S') $SERVICE is down, restarting" \
-    >> /var/log/cloud-vitals-agent-check.log
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $SERVICE is down, restarting" >> /var/log/cloud-vitals-agent-check.log
   systemctl restart "$SERVICE"
 fi

--- a/agent/cloud_vitals_agent_check.sh
+++ b/agent/cloud_vitals_agent_check.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# cloud_vitals_agent_check.sh
+# Note: Make sure this is is executable with chmod +x
+
+SERVICE=cloud_vitals_agent
+
+if ! systemctl is-active --quiet "$SERVICE"; then
+  echo "$(date '+%Y-%m-%d %H:%M:%S') $SERVICE is down, restarting" \
+    >> /var/log/cloud-vitals-agent-check.log
+  systemctl restart "$SERVICE"
+fi

--- a/agent/cloud_vitals_stress.sh
+++ b/agent/cloud_vitals_stress.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# cloud_vitals_stress.sh
+# Note: Make sure this is is executable with chmod +x
+# Usage: cloud_vitals_stress.sh <class> <duration_in_seconds>
+
+STRESS_CMD="/usr/bin/stress-ng"
+CLASS="$1"
+DURATION="${2:-60}"  # default to 60s if missing
+
+case "$CLASS" in
+  cpu)
+    ARGS=(--cpu 2 --cpu-method matrixprod) ;;
+  io)
+    ARGS=(--iomix 4) ;;
+  filesystem)
+    ARGS=(--hdd 2 --hdd-bytes 1G) ;;
+  swap)
+    TOTAL_MEM=$(grep MemTotal /proc/meminfo | awk '{print $2*1024}')
+    ARGS=(--vm 1 --vm-bytes "${TOTAL_MEM}b" --page-in) ;;
+  net)
+    ARGS=(--sockpair 2 --sockpair-ops 100000) ;;
+  *)
+    echo "Unknown class: $CLASS"
+    exit 1 ;;
+esac
+
+exec "$STRESS_CMD" "${ARGS[@]}" -t "${DURATION}s" --metrics-brief

--- a/agent/cron_job.txt
+++ b/agent/cron_job.txt
@@ -1,0 +1,1 @@
+*/5 * * * * /opt/cloud-vitals/agent/cloud_vitals_agent_check.sh >> /var/log/cloud-vitals-agent-check.log 2>&1

--- a/agent/cron_job.txt
+++ b/agent/cron_job.txt
@@ -1,1 +1,0 @@
-*/5 * * * * /opt/cloud-vitals/agent/cloud_vitals_agent_check.sh >> /var/log/cloud-vitals-agent-check.log 2>&1


### PR DESCRIPTION
* Create `cloud_vitals_agent.service` unit to manage the agent
* Add `cloud_vitals_stress.sh` for `stress‑ng` load tests
* Add `cloud_vitals_agent_check.sh` with `cron` job for health checks
* Update `agent.py` to call the stress script
* Overhauled `README.md` with full install and setup steps for Agent
