### PR TITLE
Add dashboard with live charts and stress controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,10 +124,10 @@ Make sure you have a rule (for example, `allow-agent-5000`) with these settings:
 #### **8\. Verify the agent**
 
    ```bash
-   systemctl status cloud_vitals_agent
-   journalctl -u cloud_vitals_agent -f
-   ls -l /tmp/metrics_fifo             # Check the named pipe
-   curl http://localhost:5000/metrics  # Should return JSON
+   systemctl status cloud_vitals_agent # Shows if the agent is running
+   journalctl -u cloud_vitals_agent -f # Tail its logs live
+   ls -l /tmp/metrics_fifo             # Verify the named pipe exists
+   curl http://localhost:5000/metrics  # Fetch JSON metrics from the agent
    ```
    
 #### **9\. Set up health‑check cron job**
@@ -141,7 +141,7 @@ Make sure you have a rule (for example, `allow-agent-5000`) with these settings:
      ```bash
      sudo crontab -e
      ```
-   * **Add the lin**:
+   * **Add the following at the end of the crontab file**:
      ```cron
      */5 * * * * /opt/cloud-vitals/agent/cloud_vitals_agent_check.sh >> /var/log/cloud-vitals-agent-check.log 2>&1
      ```

--- a/agent/cloud_vitals_stress.sh
+++ b/agent/cloud_vitals_stress.sh
@@ -14,11 +14,6 @@ case "$CLASS" in
     ARGS=(--iomix 4) ;;
   filesystem)
     ARGS=(--hdd 2 --hdd-bytes 1G) ;;
-  swap)
-    TOTAL_MEM=$(grep MemTotal /proc/meminfo | awk '{print $2*1024}')
-    ARGS=(--vm 1 --vm-bytes "${TOTAL_MEM}b" --page-in) ;;
-  net)
-    ARGS=(--sockpair 2 --sockpair-ops 100000) ;;
   *)
     echo "Unknown class: $CLASS"
     exit 1 ;;

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# dashboard.py
+
 """
 Cloud Vitals Dashboard
 
@@ -6,46 +9,179 @@ Periodically checks the Cloud Vital Agents' endpoints using requests,
 aggregates the returned data, and renders the resulting data visually. 
 """
 
-# dashboard.py
+import sys
+import requests
 import tkinter as tk
 import matplotlib.pyplot as plt
 from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg
 
-# create window, title and size of window
-window = tk.Tk()
-window.title("Cloud Vitals Dashboard")
-window.geometry("1350x400")
+# Agent endpoint and polling settings
+AGENT_URL       = "http://IPADDRESS:5000/metrics"
+POLL_INTERVAL   = 1000   # ms between polls
+HISTORY_LENGTH  = 60     # points to keep in each chart
 
-#figure and axis for graphs
-def add_graph(title, parent, axisY):
-    fig,ax = plt.subplots(figsize=(3,2))
-    ax.plot(axisY)
+# Stress control settings
+STRESS_URL      = AGENT_URL.replace('/metrics', '/stress')
+STRESS_DURATION = 60    # per test
+# STRESS_CLASSES  = ["cpu", "io", "filesystem", "swap", "net"]
+STRESS_CLASSES  = ["cpu", "io", "filesystem"]
+
+# Buffers for historical data
+cpu_data    = [0] * HISTORY_LENGTH
+mem_data    = [0] * HISTORY_LENGTH
+swap_data   = [0] * HISTORY_LENGTH
+disk_data   = [0] * HISTORY_LENGTH
+net_data    = [0] * HISTORY_LENGTH
+
+def make_graph(frame, title):
+    fig     = plt.figure(figsize=(3,2))
+    ax      = fig.add_subplot(1,1,1)
+    line,   = ax.plot(range(HISTORY_LENGTH), [0] * HISTORY_LENGTH)
     ax.set_title(title)
-    canvas = FigureCanvasTkAgg(fig,master=parent)
+    fig.tight_layout()
+
+    # If this is a percent chart, fix y-axis to 0-100
+    if title.endswith("%"):
+        ax.set_ylim(0, 100)
+
+    canvas = FigureCanvasTkAgg(fig, master=frame)
+    canvas.draw()
     canvas.get_tk_widget().pack()
+    return line, fig
 
+def fetch_and_update():
+    try:
+        data = requests.get(AGENT_URL, timeout=2).json()
+    except Exception:
+        # Skip this cycle on error
+        window.after(POLL_INTERVAL, fetch_and_update)
+        return
+    
+    # Shift in new samples, drop oldest
+    cpu_data.append(data.get("cpu_percent", 0));    cpu_data.pop(0)
+    mem_data.append(data.get("memory_percent", 0)); mem_data.pop(0)
+    swap_data.append(data.get("swap_percent", 0));  swap_data.pop(0)
+    disk_data.append(data.get("disk_percent", 0));  disk_data.pop(0)
+    net_data.append(data.get("network_average_bytes_per_sec", 0));  net_data.pop(0)
 
-# Header text for GUI
-header = tk.Label(window,text="Welcome to the Cloud Vitals Dashboard!", font=("Arial",16))
-header.pack(pady=20)
+    # Update lines
+    cpu_line.set_ydata(cpu_data)
+    mem_line.set_ydata(mem_data)
+    swap_line.set_ydata(swap_data)
+    disk_line.set_ydata(disk_data)
+    net_line.set_ydata(net_data)
 
-#create Frames for graphs
-cpuFrame = tk.LabelFrame(window, padx=5, pady=5)
-cpuFrame.pack(side="left",padx=10,pady=10)
-add_graph("Cpu Usage: ",cpuFrame,10)
+    # Autoscale the network axis to fit the newest data
+    net_ax = net_fig.axes[0]
+    net_ax.relim()
+    net_ax.autoscale_view()
 
-memFrame = tk.LabelFrame(window, padx=5, pady=5)
-memFrame.pack(side="left",padx=10,pady=10)
-add_graph("Memory Usage: ",memFrame,10)
+    # Redraw each figure
+    cpu_fig.canvas.draw()
+    mem_fig.canvas.draw()
+    swap_fig.canvas.draw()
+    disk_fig.canvas.draw()
+    net_fig.canvas.draw()
 
-diskFrame = tk.LabelFrame(window, padx=5, pady=5)
-diskFrame.pack(side="left",padx=10,pady=10)
-add_graph("Disk Usage: ",diskFrame,10)
+    # Update detail labels
+    for key, title in detail_specs:
+        detail_vars[key].set(f"{title}: {data.get(key, 0)}")
 
-networkFrame = tk.LabelFrame(window,padx=5, pady=5)
-networkFrame.pack(side="left", padx=10,pady=10)
-add_graph("Network Traffic: ",networkFrame,10)
+    window.after(POLL_INTERVAL, fetch_and_update)
 
+# Build UI
+window = tk.Tk()
+def on_closing():
+    # Stop the mainloop and exit the script
+    window.quit()   # Breaks out of the main loop
+    sys.exit(0)     # Terminates the process
+window.protocol("WM_DELETE_WINDOW", on_closing)
+window.title("Cloud Vitals Dashboard")
+window.geometry("1672x400")
+
+tk.Label(window, text="Cloud Vitals Dashboard", font=("Arial",16)).pack(pady=10)
+
+# Map of metric key -> (label text, StringVar)
+detail_vars = {}
+detail_specs = [
+    ("memory_total", "Mem Total"),
+    ("memory_used",  "Mem Used"),
+    ("memory_free",  "Mem Free"),
+    ("swap_total",   "Swap Total"),
+    ("swap_used",    "Swap Used"),
+    ("swap_free",    "Swap Free"),
+    ("disk_total",   "Disk Total"),
+    ("disk_used",    "Disk Used"),
+    ("disk_free",    "Disk Free"),
+]
+
+detail_vars = {}
+
+# Build the label row
+details_frame = tk.LabelFrame(window, text="Details", padx=5, pady=5)
+details_frame.pack(side="top", fill="x", padx=10, pady=5)
+
+for idx, (key, title) in enumerate(detail_specs):
+    var = tk.StringVar(value=f"{title}: 0")
+    detail_vars[key] = var
+    lbl = tk.Label(details_frame, textvariable=var, width=15, anchor="w")
+    lbl.grid(row=0, column=idx, padx=2)
+
+# Stress Toggle Buttons
+stress_running  = {cls: False for cls in STRESS_CLASSES}
+default_bg      = {}
+buttons         = {}
+def make_toggle(cls):
+    def toggle():
+        if not stress_running[cls]:
+            # Start Stress
+            try:
+                r = requests.post(STRESS_URL, json={ "class": cls, "duration": STRESS_DURATION }, timeout=2)
+                r.raise_for_status()
+            except Exception as e:
+                print(f"Failed to start {cls} stress: ", e)
+            stress_running[cls] = True
+            buttons[cls].config(text=f"Stop {cls.upper()}", bg="red")
+        else:
+            # Stop Stress
+            try:
+                r = requests.delete(f"{STRESS_URL}/{cls}", timeout=2)
+                r.raise_for_status()
+            except Exception as e:
+                print(f"Failed to stop {cls} stress: ", e)
+            stress_running[cls] = False
+            buttons[cls].config(text=f"Start {cls.upper()}", bg=default_bg[cls])
+    return toggle
+
+ctrl_frame = tk.Frame(window, pady=10)
+ctrl_frame.pack()
+
+for cls in STRESS_CLASSES:
+    btn = tk.Button(ctrl_frame, text=f"Start {cls.upper()}", command=make_toggle(cls))
+    default_bg[cls] = btn.cget("background")
+    btn.pack(side="left", padx=5)
+    buttons[cls] = btn
+
+# Create frames and graphs
+frames = {}
+for key, title in [
+    ("cpu",  "CPU %"),
+    ("mem",  "Mem %"),
+    ("swap", "Swap %"),
+    ("disk", "Disk %"),
+    ("net",  "Net B/s"),
+]:
+    f = tk.LabelFrame(window, text=title, padx=5, pady=5)
+    f.pack(side="left", padx=10, pady=10)
+    frames[key] = f
+
+# Initialize each graph and keep references
+cpu_line, cpu_fig   = make_graph(frames["cpu"],  "CPU %")
+mem_line, mem_fig   = make_graph(frames["mem"],  "Mem %")
+swap_line, swap_fig = make_graph(frames["swap"], "Swap %")
+disk_line, disk_fig = make_graph(frames["disk"], "Disk %")
+net_line, net_fig   = make_graph(frames["net"],  "Net B/s")
+
+# Start polling loop
+window.after(POLL_INTERVAL, fetch_and_update)
 window.mainloop()
-
-

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,16 @@
+certifi==2025.7.14
+charset-normalizer==3.4.2
+contourpy==1.3.2
+cycler==0.12.1
+fonttools==4.59.0
+idna==3.10
+kiwisolver==1.4.8
+matplotlib==3.10.3
+numpy==2.3.1
+packaging==25.0
+pillow==11.3.0
+pyparsing==3.2.3
+python-dateutil==2.9.0.post0
+requests==2.32.4
+six==1.17.0
+urllib3==2.5.0


### PR DESCRIPTION
- Fetch metrics from agent's `/metrics` endpoint
- Plot CPU, memory, swap, disk and network data over time
- Add buttons to start and stop each stress-ng test via the `/stress` API
- Display raw memory, swap and disk totals/usage below the graphs
- Handle window close so the app exists cleanly
- Updated `README.md` to correct typing issues and added more descriptive comments.
- Removed `stress` and `io` stress testing.

**TODO**: Improve dashboard layout.